### PR TITLE
Feature/add command to set fb start button

### DIFF
--- a/app/Console/Commands/FacebookAddStartButtonPayload.php
+++ b/app/Console/Commands/FacebookAddStartButtonPayload.php
@@ -46,7 +46,8 @@ class FacebookAddStartButtonPayload extends Command
     {
         $payload = $this->argument('payload');
 
-        $response = $this->http->post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.env('FACEBOOK_TOKEN'), [], [
+        $response = $this->http->post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.config('services.botman.facebook_token'),
+            [], [
                 "get_started" => [
                     "payload" => $payload,
                 ],

--- a/app/Console/Commands/FacebookAddStartButtonPayload.php
+++ b/app/Console/Commands/FacebookAddStartButtonPayload.php
@@ -46,7 +46,7 @@ class FacebookAddStartButtonPayload extends Command
     {
         $payload = $this->argument('payload');
 
-        $response = $this->http->post('https://graph.facebook.com/v2.66/me/messenger_profile?access_token='.env('FACEBOOK_TOKEN'), [], [
+        $response = $this->http->post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.env('FACEBOOK_TOKEN'), [], [
                 "get_started" => [
                     "payload" => $payload,
                 ],

--- a/app/Console/Commands/FacebookAddStartButtonPayload.php
+++ b/app/Console/Commands/FacebookAddStartButtonPayload.php
@@ -12,7 +12,7 @@ class FacebookAddStartButtonPayload extends Command
      *
      * @var string
      */
-    protected $signature = 'botman:facebookAddStartButton {payload}';
+    protected $signature = 'botman:facebookAddStartButton';
 
     /**
      * The console command description.
@@ -44,7 +44,12 @@ class FacebookAddStartButtonPayload extends Command
      */
     public function handle()
     {
-        $payload = $this->argument('payload');
+        $payload = config('services.botman.facebook_start_button_payload');
+
+        if (! $payload) {
+            $this->error('You need to add a Facebook payload data to your BotMan config in services.php.');
+            exit;
+        }
 
         $response = $this->http->post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.config('services.botman.facebook_token'),
             [], [

--- a/app/Console/Commands/FacebookAddStartButtonPayload.php
+++ b/app/Console/Commands/FacebookAddStartButtonPayload.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Mpociot\BotMan\Http\Curl;
+
+class FacebookAddStartButtonPayload extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'botman:facebookAddStartButton {payload}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a Facebook Get Started button with a payload';
+
+    /**
+     * @var Curl
+     */
+    private $http;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param Curl $http
+     */
+    public function __construct(Curl $http)
+    {
+        parent::__construct();
+        $this->http = $http;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $payload = $this->argument('payload');
+
+        $response = $this->http->post('https://graph.facebook.com/v2.66/me/messenger_profile?access_token='.env('FACEBOOK_TOKEN'), [], [
+                "get_started" => [
+                    "payload" => $payload,
+                ],
+            ]);
+
+        $responseObject = json_decode($response->getContent());
+
+        if ($response->getStatusCode() == 200) {
+            $this->info('Get Started payload was set to: '.$payload);
+        } else {
+            $this->error('Something went wrong: '.$responseObject->error->message);
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Console;
 
 use App\Console\Commands\BotManListen;
+use App\Console\Commands\FacebookAddStartButtonPayload;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -14,7 +15,8 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        BotManListen::class
+        BotManListen::class,
+        FacebookAddStartButtonPayload::class
     ];
 
     /**

--- a/config/services.php
+++ b/config/services.php
@@ -47,6 +47,7 @@ return [
         'nexmo_secret' => env('NEXMO_SECRET'),
         'slack_token' => env('SLACK_TOKEN'),
         'telegram_token' => env('TELEGRAM_TOKEN'),
-        'facebook_token' => env('FACEBOOK_TOKEN')
+        'facebook_token' => env('FACEBOOK_TOKEN'),
+        'facebook_start_button_payload' => ''
     ],
 ];


### PR DESCRIPTION
We talked about adding some commands to the the Laravel starter to handle some if the "one time" requests like adding a menu or like in this case the payload for the Facebook Get Started button. What do you think of that? If you like it I could provide some more.