### PR TITLE
Fix sample test.

### DIFF
--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-
 class ExampleTest extends TestCase
 {
     /**

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -13,7 +13,7 @@ class ExampleTest extends TestCase
      */
     public function testBasicExample()
     {
-        $this->visit('/')
-             ->see('Laravel');
+        $this->visit('/botman')
+            ->assertResponseStatus(200);
     }
 }


### PR DESCRIPTION
The default Laravel example test is no longer passing due to the default route being removed and a new Botman route being in its place. Just updated it to check that the `/botman` route is available.