### PR TITLE
Feature/add artisan fb menu command

### DIFF
--- a/app/Console/Commands/FacebookAddPersistentMenu.php
+++ b/app/Console/Commands/FacebookAddPersistentMenu.php
@@ -46,16 +46,13 @@ class FacebookAddPersistentMenu extends Command
     {
         $payload = config('services.botman.facebook_persistent_menu');
 
-        if (! $payload) {
+        if (!$payload) {
             $this->error('You need to add a Facebook menu payload data to your BotMan config in services.php.');
             exit;
         }
 
-        $response = $this->http->post(
-            'https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.config('services.botman.facebook_token'),
-            [],
-            $payload
-        );
+        $response = $this->http->post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.config('services.botman.facebook_token'),
+            [], $payload);
 
         $responseObject = json_decode($response->getContent());
 

--- a/app/Console/Commands/FacebookAddPersistentMenu.php
+++ b/app/Console/Commands/FacebookAddPersistentMenu.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Mpociot\BotMan\Http\Curl;
+
+class FacebookAddPersistentMenu extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'botman:facebookAddMenu';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a persistent Facebook menu';
+
+    /**
+     * @var Curl
+     */
+    private $http;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param Curl $http
+     */
+    public function __construct(Curl $http)
+    {
+        parent::__construct();
+        $this->http = $http;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $payload = config('services.botman.facebook_persistent_menu');
+
+        if (! $payload) {
+            $this->error('You need to add a Facebook menu payload data to your BotMan config in services.php.');
+            exit;
+        }
+
+        $response = $this->http->post(
+            'https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.config('services.botman.facebook_token'),
+            [],
+            $payload
+        );
+
+        $responseObject = json_decode($response->getContent());
+
+        if ($response->getStatusCode() == 200) {
+            $this->info('Facebook menu was set.');
+        } else {
+            $this->error('Something went wrong: '.$responseObject->error->message);
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,7 +3,6 @@
 namespace App\Console;
 
 use App\Console\Commands\BotManListen;
-use App\Console\Commands\BotManTinker;
 use App\Console\Commands\FacebookAddPersistentMenu;
 use App\Console\Commands\FacebookAddStartButtonPayload;
 use Illuminate\Console\Scheduling\Schedule;
@@ -19,13 +18,13 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         BotManListen::class,
         FacebookAddStartButtonPayload::class,
-        FacebookAddPersistentMenu::class
+        FacebookAddPersistentMenu::class,
     ];
 
     /**
      * Define the application's command schedule.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @param \Illuminate\Console\Scheduling\Schedule $schedule
      * @return void
      */
     protected function schedule(Schedule $schedule)

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use App\Console\Commands\BotManListen;
 use App\Console\Commands\BotManTinker;
+use App\Console\Commands\FacebookAddPersistentMenu;
 use App\Console\Commands\FacebookAddStartButtonPayload;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -17,7 +18,8 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         BotManListen::class,
-        FacebookAddStartButtonPayload::class
+        FacebookAddStartButtonPayload::class,
+        FacebookAddPersistentMenu::class
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -25,6 +25,7 @@ class Kernel extends ConsoleKernel
      * Define the application's command schedule.
      *
      * @param \Illuminate\Console\Scheduling\Schedule $schedule
+     *
      * @return void
      */
     protected function schedule(Schedule $schedule)

--- a/config/services.php
+++ b/config/services.php
@@ -62,7 +62,7 @@ return [
                                     'title'   => 'Pay Bill',
                                     'type'    => 'postback',
                                     'payload' => 'PAYBILL_PAYLOAD',
-                                ]
+                                ],
                             ],
                         ],
                         [
@@ -70,7 +70,7 @@ return [
                             'title'                => 'Latest News',
                             'url'                  => 'http://botman.io',
                             'webview_height_ratio' => 'full',
-                        ]
+                        ],
                     ],
                 ],
             ],

--- a/config/services.php
+++ b/config/services.php
@@ -20,7 +20,7 @@ return [
     ],
 
     'ses' => [
-        'key' => env('SES_KEY'),
+        'key'    => env('SES_KEY'),
         'secret' => env('SES_SECRET'),
         'region' => 'us-east-1',
     ],
@@ -30,50 +30,50 @@ return [
     ],
 
     'stripe' => [
-        'model' => App\User::class,
-        'key' => env('STRIPE_KEY'),
+        'model'  => App\User::class,
+        'key'    => env('STRIPE_KEY'),
         'secret' => env('STRIPE_SECRET'),
     ],
 
     'botman' => [
         'hipchat_urls' => [
-            env('HIPCHAT_URL')
+            env('HIPCHAT_URL'),
         ],
-        'microsoft_bot_handle' => env('MICROSOFT_BOT_HANDLE'),
-        'microsoft_app_id' => env('MICROSOFT_APP_ID'),
-        'microsoft_app_key' => env('MICROSOFT_APP_KEY'),
-        'nexmo_key' => env('NEXMO_KEY'),
-        'nexmo_secret' => env('NEXMO_SECRET'),
-        'slack_token' => env('SLACK_TOKEN'),
-        'telegram_token' => env('TELEGRAM_TOKEN'),
-        'facebook_token' => env('FACEBOOK_TOKEN'),
+        'microsoft_bot_handle'          => env('MICROSOFT_BOT_HANDLE'),
+        'microsoft_app_id'              => env('MICROSOFT_APP_ID'),
+        'microsoft_app_key'             => env('MICROSOFT_APP_KEY'),
+        'nexmo_key'                     => env('NEXMO_KEY'),
+        'nexmo_secret'                  => env('NEXMO_SECRET'),
+        'slack_token'                   => env('SLACK_TOKEN'),
+        'telegram_token'                => env('TELEGRAM_TOKEN'),
+        'facebook_token'                => env('FACEBOOK_TOKEN'),
         'facebook_start_button_payload' => '',
-        'facebook_persistent_menu' => [
+        'facebook_persistent_menu'      => [
             'persistent_menu' => [
                 [
-                    'locale' => 'default',
+                    'locale'                  => 'default',
                     'composer_input_disabled' => 'true',
-                    'call_to_actions' => [
+                    'call_to_actions'         => [
                         [
-                            'title' => 'My Account',
-                            'type' => 'nested',
+                            'title'           => 'My Account',
+                            'type'            => 'nested',
                             'call_to_actions' => [
                                 [
-                                    'title' => 'Pay Bill',
-                                    'type' => 'postback',
+                                    'title'   => 'Pay Bill',
+                                    'type'    => 'postback',
                                     'payload' => 'PAYBILL_PAYLOAD'
                                 ]
                             ],
                         ],
                         [
-                            'type' => 'web_url',
-                            'title' => 'Latest News',
-                            'url' => 'http://botman.io',
+                            'type'                 => 'web_url',
+                            'title'                => 'Latest News',
+                            'url'                  => 'http://botman.io',
                             'webview_height_ratio' => 'full'
                         ]
                     ],
-                ]
-            ]
-        ]
+                ],
+            ],
+        ],
     ],
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -61,7 +61,7 @@ return [
                                 [
                                     'title'   => 'Pay Bill',
                                     'type'    => 'postback',
-                                    'payload' => 'PAYBILL_PAYLOAD'
+                                    'payload' => 'PAYBILL_PAYLOAD',
                                 ]
                             ],
                         ],
@@ -69,7 +69,7 @@ return [
                             'type'                 => 'web_url',
                             'title'                => 'Latest News',
                             'url'                  => 'http://botman.io',
-                            'webview_height_ratio' => 'full'
+                            'webview_height_ratio' => 'full',
                         ]
                     ],
                 ],

--- a/config/services.php
+++ b/config/services.php
@@ -35,7 +35,6 @@ return [
         'secret' => env('STRIPE_SECRET'),
     ],
 
-
     'botman' => [
         'hipchat_urls' => [
             env('HIPCHAT_URL')
@@ -48,6 +47,33 @@ return [
         'slack_token' => env('SLACK_TOKEN'),
         'telegram_token' => env('TELEGRAM_TOKEN'),
         'facebook_token' => env('FACEBOOK_TOKEN'),
-        'facebook_start_button_payload' => ''
+        'facebook_start_button_payload' => '',
+        'facebook_persistent_menu' => [
+            'persistent_menu' => [
+                [
+                    'locale' => 'default',
+                    'composer_input_disabled' => 'true',
+                    'call_to_actions' => [
+                        [
+                            'title' => 'My Account',
+                            'type' => 'nested',
+                            'call_to_actions' => [
+                                [
+                                    'title' => 'Pay Bill',
+                                    'type' => 'postback',
+                                    'payload' => 'PAYBILL_PAYLOAD'
+                                ]
+                            ],
+                        ],
+                        [
+                            'type' => 'web_url',
+                            'title' => 'Latest News',
+                            'url' => 'http://botman.io',
+                            'webview_height_ratio' => 'full'
+                        ]
+                    ],
+                ]
+            ]
+        ]
     ],
 ];

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,10 @@ $botman->hears('YOUR_PAYLOAD_TEXT', function (BotMan $bot) {
 });
 ```
 
+### Add Facebook Get Started button
+
+With this starter project it now gets much easier to add a persistent Facebook menu to your bot. First define the structure and types of your menu in your `services.php` config file. There you will find a demo menu payload. Just edit it to your needs. You can read more about the menu possibilities in the [Facebook Docs](https://developers.facebook.com/docs/messenger-platform/messenger-profile/persistent-menu#post). Then run the artisan command `php artisan botman:facebookAddMenu` to create or update the Facebook menu. 
+
 ## License
 
 BotMan and this boilerplate is free software distributed under the terms of the MIT license.


### PR DESCRIPTION
This makes it possible to create a persistent Facebook menu with an artisan command `php artisan botman:facebookAddMenu`. The structure is defined in the `services.php` file.

Only downside I see is, that the whole demo structure is in the services.php file. But it is much easier for the user to have this demo structure, because creating this array is very buggy.
