### PR TITLE
Speed up tests

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Support\Facades\Hash;
 use BotMan\Studio\Testing\BotManTester;
 use BotMan\BotMan\Drivers\DriverManager;
 use Illuminate\Contracts\Console\Kernel;
@@ -27,6 +28,8 @@ trait CreatesApplication
 
         $this->botman = $app->make('botman');
         $this->bot = new BotManTester($this->botman, $fakeDriver, $this);
+
+        Hash::setRounds(5);
 
         return $app;
     }


### PR DESCRIPTION
This simple PR sets hash rounds to lower the default crypt cost factor and speed up tests whenever the you're using hashing (eg. when you create users during your tests and authenticate them).