### PR TITLE
Fix the text bar to the bottom on tinker page

### DIFF
--- a/resources/views/tinker.blade.php
+++ b/resources/views/tinker.blade.php
@@ -29,6 +29,11 @@
         .content {
             text-align: center;
         }
+                
+        #app {
+            position: absolute;
+            bottom: 10px;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
This way, the tinker page looks and behaves like a real chat app. Otherwise scroll is acting weird if the conversation is long enough