### PR TITLE
Update with latest set of quotes from Laravel 5.8

### DIFF
--- a/tests/BotMan/ExampleTest.php
+++ b/tests/BotMan/ExampleTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\BotMan;
 
-use Illuminate\Foundation\Inspiring;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase

--- a/tests/BotMan/ExampleTest.php
+++ b/tests/BotMan/ExampleTest.php
@@ -38,6 +38,8 @@ class ExampleTest extends TestCase
             'It is quality rather than quantity that matters. - Lucius Annaeus Seneca',
             'Genius is one percent inspiration and ninety-nine percent perspiration. - Thomas Edison',
             'Computer science is no more about computers than astronomy is about telescopes. - Edsger Dijkstra',
+            'It always seems impossible until it is done. - Nelson Mandela',
+            'Act only according to that maxim whereby you can, at the same time, will that it should become a universal law. - Immanuel Kant',
         ];
 
         $this->bot


### PR DESCRIPTION
The testConversationBasicTest seemingly randomly fails. This is due to two additional quotes in the Laravel Inspire package that haven't been incorporated into this test yet. When either of those two additional quotes are returned, the test files.

Fixed this to avoid confusion for new users running first-time tests.