### PR TITLE
Fix namespace of BotManTester in tests/TestCase.php

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use App\BotManTester;
 use BotMan\BotMan\BotMan;
+use BotMan\Studio\Testing\BotManTester;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase


### PR DESCRIPTION
Hello,

I've run into this small issue where the namespace for BotManTester is wrong.
All the tests pass because this is just an annotation but without this change, all Tests->bot show you a reference to non existing "App\BotManTester" :)

Hope this makes sence.
Thank you for this project.

--
before
![2020-06-23_0710](https://user-images.githubusercontent.com/34166829/85376534-231b2900-b538-11ea-9469-b9c557c45dcc.png)

-- after
![2020-06-23_0711](https://user-images.githubusercontent.com/34166829/85376547-27dfdd00-b538-11ea-833e-2b0bc3a49919.png)
